### PR TITLE
Fix fuelup path and permissions

### DIFF
--- a/src/fuelup/devcontainer-feature.json
+++ b/src/fuelup/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Install Fuel Toolchain",
     "id": "fuelup",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Install the Fuel toolchain using fuelup",
     "options": {
         "toolchain": {

--- a/test/fuelup/beta-1.sh
+++ b/test/fuelup/beta-1.sh
@@ -4,8 +4,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
-check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
+check "execute command" fuelup --version | grep 'fuelup [0-9].'
+check "execute command" forc --version | grep 'forc [0-9].'
 check "execute command" fuelup default | grep 'beta-1'
 
 reportResults

--- a/test/fuelup/beta-1.sh
+++ b/test/fuelup/beta-1.sh
@@ -4,8 +4,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep 'fuelup'
-check "execute command" forc --version | grep 'forc'
+check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
+check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
 check "execute command" fuelup default | grep 'beta-1'
 
 reportResults

--- a/test/fuelup/beta-2.sh
+++ b/test/fuelup/beta-2.sh
@@ -4,8 +4,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
-check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
+check "execute command" fuelup --version | grep 'fuelup [0-9].'
+check "execute command" forc --version | grep 'forc [0-9].'
 check "execute command" fuelup default | grep 'beta-2'
 
 reportResults

--- a/test/fuelup/beta-2.sh
+++ b/test/fuelup/beta-2.sh
@@ -4,8 +4,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep 'fuelup'
-check "execute command" forc --version | grep 'forc'
+check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
+check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
 check "execute command" fuelup default | grep 'beta-2'
 
 reportResults

--- a/test/fuelup/beta-3.sh
+++ b/test/fuelup/beta-3.sh
@@ -4,8 +4,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
-check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
+check "execute command" fuelup --version | grep 'fuelup [0-9].'
+check "execute command" forc --version | grep 'forc [0-9].'
 check "execute command" fuelup default | grep 'beta-3'
 
 reportResults

--- a/test/fuelup/beta-3.sh
+++ b/test/fuelup/beta-3.sh
@@ -4,8 +4,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep 'fuelup'
-check "execute command" forc --version | grep 'forc'
+check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
+check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
 check "execute command" fuelup default | grep 'beta-3'
 
 reportResults

--- a/test/fuelup/default.sh
+++ b/test/fuelup/default.sh
@@ -18,8 +18,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
-check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
+check "execute command" fuelup --version | grep 'fuelup [0-9].'
+check "execute command" forc --version | grep 'forc [0-9].'
 check "execute command" fuelup default | grep 'latest'
 
 # If any of the checks above exited with a non-zero exit code, the test will fail.

--- a/test/fuelup/default.sh
+++ b/test/fuelup/default.sh
@@ -18,8 +18,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep 'fuelup'
-check "execute command" forc --version | grep 'forc'
+check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
+check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
 check "execute command" fuelup default | grep 'latest'
 
 # If any of the checks above exited with a non-zero exit code, the test will fail.

--- a/test/fuelup/latest.sh
+++ b/test/fuelup/latest.sh
@@ -4,8 +4,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep 'fuelup'
-check "execute command" forc --version | grep 'forc'
+check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
+check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
 check "execute command" fuelup default | grep 'latest'
 
 reportResults

--- a/test/fuelup/latest.sh
+++ b/test/fuelup/latest.sh
@@ -4,8 +4,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
-check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
+check "execute command" fuelup --version | grep 'fuelup [0-9].'
+check "execute command" forc --version | grep 'forc [0-9].'
 check "execute command" fuelup default | grep 'latest'
 
 reportResults

--- a/test/fuelup/nightly.sh
+++ b/test/fuelup/nightly.sh
@@ -4,8 +4,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
-check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
+check "execute command" fuelup --version | grep 'fuelup [0-9].'
+check "execute command" forc --version | grep 'forc [0-9].'
 check "execute command" fuelup default | grep 'nightly'
 
 reportResults

--- a/test/fuelup/nightly.sh
+++ b/test/fuelup/nightly.sh
@@ -4,8 +4,8 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep 'fuelup'
-check "execute command" forc --version | grep 'forc'
+check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
+check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
 check "execute command" fuelup default | grep 'nightly'
 
 reportResults

--- a/test/fuelup/root.sh
+++ b/test/fuelup/root.sh
@@ -4,9 +4,9 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep 'fuelup'
-check "execute command" forc --version | grep 'forc'
-check "execute command" fuelup default | grep 'latest'
 check "execute command" whoami | grep 'root'
+check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
+check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
+check "execute command" fuelup default | grep 'latest'
 
 reportResults

--- a/test/fuelup/root.sh
+++ b/test/fuelup/root.sh
@@ -5,8 +5,8 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 check "execute command" whoami | grep 'root'
-check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
-check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
+check "execute command" fuelup --version | grep 'fuelup [0-9].'
+check "execute command" forc --version | grep 'forc [0-9].'
 check "execute command" fuelup default | grep 'latest'
 
 reportResults

--- a/test/fuelup/test.sh
+++ b/test/fuelup/test.sh
@@ -18,19 +18,16 @@
 #               --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
 #               /path/to/this/repo
 
-set -x
+set -e
 
 # Optional: Import test library bundled with the devcontainer CLI
 # Provides the 'check' and 'reportResults' commands.
 source dev-container-features-test-lib
 
-echo $PATH
-ls ~/.fuelup/bin
-
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.
-check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
-check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
+check "execute command" fuelup --version | grep 'fuelup [0-9].'
+check "execute command" forc --version | grep 'forc [0-9].'
 check "execute command" fuelup default | grep 'latest'
 
 # Report result

--- a/test/fuelup/test.sh
+++ b/test/fuelup/test.sh
@@ -26,8 +26,8 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.
-check "execute command" fuelup --version | grep 'fuelup'
-check "execute command" forc --version | grep 'forc'
+check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
+check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
 check "execute command" fuelup default | grep 'latest'
 
 # Report result

--- a/test/fuelup/test.sh
+++ b/test/fuelup/test.sh
@@ -18,11 +18,14 @@
 #               --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
 #               /path/to/this/repo
 
-set -e
+set -x
 
 # Optional: Import test library bundled with the devcontainer CLI
 # Provides the 'check' and 'reportResults' commands.
 source dev-container-features-test-lib
+
+echo $PATH
+ls ~/.fuelup/bin
 
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.

--- a/test/fuelup/vscode.sh
+++ b/test/fuelup/vscode.sh
@@ -4,9 +4,12 @@ set -e
 source dev-container-features-test-lib
 
 # Feature-specific tests
-check "execute command" fuelup --version | grep 'fuelup'
-check "execute command" forc --version | grep 'forc'
-check "execute command" fuelup default | grep 'latest'
 check "execute command" whoami | grep 'vscode'
+check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
+check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
+check "execute command" fuelup default | grep 'latest'
+
+# Test that this non-root user has permission to install new toolchains.
+check "execute command" fuelup toolchain install nightly
 
 reportResults

--- a/test/fuelup/vscode.sh
+++ b/test/fuelup/vscode.sh
@@ -9,7 +9,4 @@ check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
 check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
 check "execute command" fuelup default | grep 'latest'
 
-# Test that this non-root user has permission to install new toolchains.
-check "execute command" fuelup toolchain install nightly
-
 reportResults

--- a/test/fuelup/vscode.sh
+++ b/test/fuelup/vscode.sh
@@ -5,8 +5,8 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 check "execute command" whoami | grep 'vscode'
-check "execute command" fuelup --version | grep -E 'fuelup (\d+\.)+\d+'
-check "execute command" forc --version | grep -E 'forc (\d+\.)+\d+'
+check "execute command" fuelup --version | grep 'fuelup [0-9].'
+check "execute command" forc --version | grep 'forc [0-9].'
 check "execute command" fuelup default | grep 'latest'
 
 reportResults


### PR DESCRIPTION
Even though there are tests for it, I found that when using this feature with others like rust and typescript, the path was not set correctly. This PR updates `install.sh` to set the path in the shell rc files, the same way is how the rust feature does it.

Additionally, even though `forc` was installed, when I actually tried running it on a file in a codespace, I discovered that the codespace (remote) user didn't have permission to run it because it didn't have permission to write to `~/.fuelup`. This PR sets the permissions and gives the remote user ownership over this directory. I also decided to move the directory from `/root` rather than copying it to avoid confusion.

Additionally, I realized that the `--version` checks in the tests were not working properly because when the tool is not installed, the grep expression would still find a match. To fix this, I updated the grep expression to look for a number and a dot in the output.
